### PR TITLE
Order of arguments and check for bounds in simulations.py

### DIFF
--- a/dolo/algos/dtcscc/simulations.py
+++ b/dolo/algos/dtcscc/simulations.py
@@ -156,7 +156,7 @@ def simulate(model, dr, s0=None, n_exp=0, horizon=40, seed=1, discard=False,
         return panel
 
 
-def plot_decision_rule(model, dr, state, grid={}, plot_controls=None, bounds=None,
+def plot_decision_rule(model, dr, state, plot_controls=None, grid={}, bounds=None,
                        n_steps=10, s0=None, **kwargs):
     """
     Plots decision rule
@@ -202,9 +202,10 @@ def plot_decision_rule(model, dr, state, grid={}, plot_controls=None, bounds=Non
     controls_names = model.symbols['controls']
     index = states_names.index(str(state))
 
-
-    approx = model.get_grid(**grid)
-    bounds = [approx.a[index], approx.b[index]]
+    if bounds is None:
+        approx = model.get_grid(**grid)
+        bounds = [approx.a[index], approx.b[index]]
+        return bounds
 
     values = numpy.linspace(bounds[0], bounds[1], n_steps)
     if s0 is None:

--- a/dolo/algos/dtcscc/simulations.py
+++ b/dolo/algos/dtcscc/simulations.py
@@ -202,7 +202,7 @@ def plot_decision_rule(model, dr, state, plot_controls=None, grid={}, bounds=Non
     controls_names = model.symbols['controls']
     index = states_names.index(str(state))
 
-    if bounds is None:
+    if 'bounds' is None:
         bounds = [dr.smin[index], dr.smax[index]]
         #approx = model.get_grid(**grid)
         #bounds = [approx.a[index], approx.b[index]]

--- a/dolo/algos/dtcscc/simulations.py
+++ b/dolo/algos/dtcscc/simulations.py
@@ -203,8 +203,9 @@ def plot_decision_rule(model, dr, state, plot_controls=None, grid={}, bounds=Non
     index = states_names.index(str(state))
 
     if bounds is None:
-        approx = model.get_grid(**grid)
-        bounds = [approx.a[index], approx.b[index]]
+        bounds = [dr.smin[index], dr.smax[index]]
+        #approx = model.get_grid(**grid)
+        #bounds = [approx.a[index], approx.b[index]]
         return bounds
 
     values = numpy.linspace(bounds[0], bounds[1], n_steps)

--- a/dolo/algos/dtcscc/simulations.py
+++ b/dolo/algos/dtcscc/simulations.py
@@ -202,11 +202,14 @@ def plot_decision_rule(model, dr, state, plot_controls=None, grid={}, bounds=Non
     controls_names = model.symbols['controls']
     index = states_names.index(str(state))
 
-    if 'bounds' is None:
-        bounds = [dr.smin[index], dr.smax[index]]
-        #approx = model.get_grid(**grid)
-        #bounds = [approx.a[index], approx.b[index]]
-        return bounds
+    if bounds is None:
+        try:
+            bounds = [dr.smin[index], dr.smax[index]]
+        except:
+            approx = model.get_grid(**grid)
+            bounds = [approx.a[index], approx.b[index]]
+        if bounds is None:
+            raise Exception("No bounds provided for simulation or by model.")
 
     values = numpy.linspace(bounds[0], bounds[1], n_steps)
     if s0 is None:

--- a/dolo/algos/dtmscc/simulations.py
+++ b/dolo/algos/dtmscc/simulations.py
@@ -184,8 +184,9 @@ def plot_decision_rule(model, dr, state, plot_controls=None, bounds=None, n_step
     controls_names = model.symbols['controls']
     index = states_names.index(str(state))
 
-    if bounds is None:
+    if 'bounds' is None:
         bounds = [dr.smin[index], dr.smax[index]]
+        return bounds
 
     values = numpy.linspace(bounds[0], bounds[1], n_steps)
 

--- a/dolo/algos/dtmscc/simulations.py
+++ b/dolo/algos/dtmscc/simulations.py
@@ -184,9 +184,14 @@ def plot_decision_rule(model, dr, state, plot_controls=None, bounds=None, n_step
     controls_names = model.symbols['controls']
     index = states_names.index(str(state))
 
-    if 'bounds' is None:
-        bounds = [dr.smin[index], dr.smax[index]]
-        return bounds
+    if bounds is None:
+        try:
+            bounds = [dr.smin[index], dr.smax[index]]
+        except:
+            approx = model.get_grid(**grid)
+            bounds = [approx.a[index], approx.b[index]]
+        if bounds is None:
+            raise Exception("No bounds provided for simulation or by model.")
 
     values = numpy.linspace(bounds[0], bounds[1], n_steps)
 

--- a/dolo/tests/test_simulations.py
+++ b/dolo/tests/test_simulations.py
@@ -1,0 +1,34 @@
+from dolo import *
+
+def test_simulations_dtcscc():
+    model = yaml_import("examples/models/rbc.yaml")
+    dr = approximate_controls(model)
+    sim = plot_decision_rule(model,dr,'k')
+
+def test_simulations_dtcscc_getcorrectbounds():
+    model = yaml_import("examples/models/rbc.yaml")
+    kss = model.get_calibration('k')
+
+    dr = approximate_controls(model)
+    sim = plot_decision_rule(model,dr,'k',bounds=[1.0,10.0])
+    assert(sim['k'].iloc[0] == 1.0)
+    assert(sim['k'].iloc[-1] == 10.0)
+
+def test_simulations_dtcscc_getcorrectbounds2():
+    model = yaml_import("examples/models/rbc.yaml")
+    dr = approximate_controls(model)
+    sim = plot_decision_rule(model,dr,'k')
+    assert(not(sim['k'].iloc[0] == 1.0))
+    assert(not(sim['k'].iloc[-1] == 10.0))
+
+def test_simulations_dtmscc():
+    model = yaml_import("examples/models/rbc_dtmscc.yaml")
+    dr = time_iteration(model)
+    sim = plot_decision_rule(model,dr,'k')
+
+def test_simulations_dtmscc_getcorrectbounds():
+    model = yaml_import("examples/models/rbc_dtmscc.yaml")
+    dr = time_iteration(model)
+    sim = plot_decision_rule(model,dr,'k',bounds=[1.0,10.0])
+    assert(sim['k'].iloc[0] == 1.0)
+    assert(sim['k'].iloc[-1] == 10.0)


### PR DESCRIPTION
1. In the 'dtcscc\simulations.py', inside the function 'plot_decision_rule': changed the order of the arguments 'grid' and 'plot_controls'. This returns to being consistent with the order in the same function in 'dtmscc\simulations.py', and also consistent with the order of arguments inside the RBC model tutorial. Running the tutorial as the code was previously would generate an error because the plot_control was being interpreted as a grid object. 

2. In the 'dtcscc' folder, in 'simulations.py', and inside the function 'plot_decision_rule': added a check to see if bounds are provided. If so, then use those bounds; if not, then use bounds associated with the decision rule object. Note that I have used the '[dr.smin[index], dr.smax[index]]' format instead of 'model.get_grid(**grid)' to keep consistent with what is in 'dtmscc/simulations.py'. Have left the latter format commented in case that is preferred. 