### PR TITLE
FIX: included 'expectations' as a symbol type in arbitrage_exp section

### DIFF
--- a/dolo/compiler/recipes.yaml
+++ b/dolo/compiler/recipes.yaml
@@ -81,6 +81,7 @@ dtcscc:
             eqs:
                 - ['states',0,'s']
                 - ['controls',0,'x']
+                - ['expectations', 0, 'z']
                 #- ['auxiliaries',0,'y']
                 - ['parameters', 0, 'p']
 
@@ -182,8 +183,10 @@ dtmscc:
             optional: True
 
             eqs:
+                - ['markov_states',0,'m']
                 - ['states',0,'s']
                 - ['controls',0,'x']
+                - ['expectations', 0, 'z']
                 #- ['auxiliaries',0,'y']
                 - ['parameters', 0, 'p']
 


### PR DESCRIPTION
Fixed to make sure that 'expectations' symbols show up in the arbitrage_exp sections (in both dtcscc and dtmscc), so that expectations model objects are recognized. 

Also a small fix to include 'markov states' symbols in the dtmscc section.