### PR TITLE
ENH: indirect method for parameterized expectatiions algorithm

### DIFF
--- a/dolo/algos/dtcscc/parameterized_expectations.py
+++ b/dolo/algos/dtcscc/parameterized_expectations.py
@@ -1,6 +1,153 @@
 import time
 import numpy as np
 from dolo.algos.dtcscc.perturbations import approximate_controls
+from dolo.numeric.optimize.newton import (SerialDifferentiableFunction,
+                                          serial_newton)
+from dolo.numeric.interpolation import create_interpolator
+
+
+def parameterized_expectations(model, verbose=False, initial_dr=None,
+                               pert_order=1, grid={}, distribution={},
+                               maxit=100, tol=1e-8):
+    '''
+    Finds a global solution for ``model`` using parameterized expectations
+    function. Requires the model to be written with controls as a direct
+    function of the model objects.
+
+    The algorithm iterates on the expectations function in the arbitrage
+    equation. It follows the discussion in section 9.9 of Miranda and
+    Fackler (2002).
+
+    Parameters
+    ----------
+    model : NumericModel
+        "dtcscc" model to be solved
+    verbose : boolean
+        if True, display iterations
+    initial_dr : decision rule
+        initial guess for the decision rule
+    pert_order : {1}
+        if no initial guess is supplied, the perturbation solution at order
+        ``pert_order`` is used as initial guess
+    grid: grid options
+    distribution: distribution options
+    maxit: maximum number of iterations
+    tol: tolerance criterium for successive approximations
+
+    Returns
+    -------
+    decision rule :
+        approximated solution
+    '''
+
+    t1 = time.time()
+
+    g = model.functions['transition']
+    f = model.functions['arbitrage_exp']  # f(s, x, z, p, out)
+    h = model.functions['expectation']
+    parms = model.calibration['parameters']
+
+    if initial_dr is None:
+        if pert_order == 1:
+            initial_dr = approximate_controls(model)
+
+        if pert_order > 1:
+            raise Exception("Perturbation order > 1 not supported (yet).")
+
+    approx = model.get_grid(**grid)
+    grid = approx.grid
+    interp_type = approx.interpolation
+    dr = create_interpolator(approx, interp_type)
+    expect = create_interpolator(approx, interp_type)
+
+    distrib = model.get_distribution(**distribution)
+    nodes, weights = distrib.discretize()
+
+    N = grid.shape[0]
+    z = np.zeros((N, len(model.symbols['expectations'])))
+
+    x_0 = initial_dr(grid)
+    x_0 = x_0.real  # just in case ...
+    h_0 = h(grid, x_0, parms)
+
+    it = 0
+    err = 10
+    err_0 = 10
+
+    verbit = True if verbose == 'full' else False
+
+    if verbose:
+        headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'
+        headline = headline.format('N', ' Error', 'Gain', 'Time')
+        stars = '-'*len(headline)
+        print(stars)
+        print(headline)
+        print(stars)
+
+        # format string for within loop
+        fmt_str = '|{0:4} | {1:10.3e} | {2:8.3f} | {3:8.3f} |'
+
+    while err > tol and it <= maxit:
+
+        it += 1
+        t_start = time.time()
+
+        # dr.set_values(x_0)
+        expect.set_values(h_0)
+
+        # evaluate expectation over the future state
+        z[...] = 0
+        for i in range(weights.shape[0]):
+            e = nodes[i, :]
+            S = g(grid, x_0, e, parms)
+            z += weights[i]*expect(S)
+
+        # Solve arbitrage equations for the control
+        def fun(x): return f(grid, x, z, parms)
+
+        sdfun = SerialDifferentiableFunction(fun)
+        [new_x, nit] = serial_newton(sdfun, x_0, verbose=verbit)
+
+        new_h = h(grid, new_x, parms)
+        # TODO: check that control is admissible
+
+        # update error
+        err = (abs(new_h - h_0).max())
+
+        # Update guess for decision rule and expectations function
+        x_0 = new_x
+        h_0 = new_h
+
+        # print error infomation if `verbose`
+        err_SA = err/err_0
+        err_0 = err
+        t_finish = time.time()
+        elapsed = t_finish - t_start
+        if verbose:
+            print(fmt_str.format(it, err, err_SA, elapsed))
+
+
+
+    if it == maxit:
+        import warnings
+        warnings.warn(UserWarning("Maximum number of iterations reached"))
+
+    # compute final fime and do final printout if `verbose`
+    t2 = time.time()
+    if verbose:
+        print(stars)
+        print('Elapsed: {} seconds.'.format(t2 - t1))
+        print(stars)
+
+    # Interpolation for the decision rule
+    dr.set_values(x_0)
+
+    return dr
+
+
+import time
+import numpy as np
+from dolo.algos.dtcscc.perturbations import approximate_controls
 from dolo.numeric.interpolation import create_interpolator
 
 
@@ -101,12 +248,14 @@ def parameterized_expectations_direct(model, verbose=False, initial_dr=None,
         new_x = d(grid, z, parms)
         new_h = h(grid, new_x, parms)
 
+        # update error
+        err = (abs(new_h - h_0).max())
+
         # Update guess for decision rule and expectations function
         x_0 = new_x
         h_0 = new_h
 
-        # update error and print if `verbose`
-        err = (abs(new_h - h_0).max())
+        # print error information if `verbose`
         err_SA = err/err_0
         err_0 = err
         t_finish = time.time()

--- a/dolo/algos/dtcscc/time_iteration.py
+++ b/dolo/algos/dtcscc/time_iteration.py
@@ -328,11 +328,13 @@ def time_iteration_direct(model, verbose=False, initial_dr=None,
         # TODO: check that control is admissible
         new_x = d(grid, z, parms)
 
+        # update error
+        err = (abs(new_x - x_0).max())
+
         # Update control vector
         x_0[:] = new_x
 
-        # update error and print if `verbose`
-        err = (abs(new_x - x_0).max())
+        # print error information if `verbose`
         err_SA = err/err_0
         err_0 = err
         t_finish = time.time()

--- a/dolo/tests/test_parameterized_expectations.py
+++ b/dolo/tests/test_parameterized_expectations.py
@@ -17,3 +17,25 @@ def test_parameterized_expectations_direct():
 
 if __name__ =='__main__':
     test_parameterized_expectations_direct()
+
+
+
+def test_parameterized_expectations_direct():
+
+    from dolo import yaml_import
+    from dolo.algos.dtcscc.parameterized_expectations import parameterized_expectations
+    from dolo.algos.dtcscc.time_iteration import time_iteration
+
+    model = yaml_import("examples/models/rbc_full.yaml")
+
+    dr_ti = time_iteration(model)
+    dr_pea = parameterized_expectations(model)
+
+    x_ti  = dr_ti(dr_ti.grid)
+    x_pea = dr_pea(dr_ti.grid)
+
+    print(abs(x_ti - x_pea).max()<1e-5)
+
+
+if __name__ =='__main__':
+    test_parameterized_expectations_direct()

--- a/dolo/tests/test_parameterized_expectations.py
+++ b/dolo/tests/test_parameterized_expectations.py
@@ -1,26 +1,24 @@
 def test_parameterized_expectations_direct():
 
     from dolo import yaml_import
-    from dolo.algos.dtcscc.parameterized_expectations import  parameterized_expectations_direct
+    from dolo.algos.dtcscc.parameterized_expectations import parameterized_expectations
     from dolo.algos.dtcscc.time_iteration import time_iteration_direct
 
     model = yaml_import("examples/models/rbc_full.yaml")
 
     dr_ti = time_iteration_direct(model)
-    dr_pea = parameterized_expectations_direct(model)
+    dr_pea = parameterized_expectations(model, direct=True)
 
-    x_ti  = dr_ti(dr_ti.grid)
+    x_ti = dr_ti(dr_ti.grid)
     x_pea = dr_pea(dr_ti.grid)
 
-    print(abs(x_ti - x_pea).max()<1e-5)
+    print(abs(x_ti - x_pea).max() < 1e-5)
 
-
-if __name__ =='__main__':
+if __name__ == '__main__':
     test_parameterized_expectations_direct()
 
 
-
-def test_parameterized_expectations_direct():
+def test_parameterized_expectations():
 
     from dolo import yaml_import
     from dolo.algos.dtcscc.parameterized_expectations import parameterized_expectations
@@ -29,13 +27,12 @@ def test_parameterized_expectations_direct():
     model = yaml_import("examples/models/rbc_full.yaml")
 
     dr_ti = time_iteration(model)
-    dr_pea = parameterized_expectations(model)
+    dr_pea = parameterized_expectations(model, direct=False)
 
-    x_ti  = dr_ti(dr_ti.grid)
+    x_ti = dr_ti(dr_ti.grid)
     x_pea = dr_pea(dr_ti.grid)
 
-    print(abs(x_ti - x_pea).max()<1e-5)
+    print(abs(x_ti - x_pea).max() < 1e-5)
 
-
-if __name__ =='__main__':
-    test_parameterized_expectations_direct()
+if __name__ == '__main__':
+    test_parameterized_expectations()

--- a/examples/models/rbc_full.yaml
+++ b/examples/models/rbc_full.yaml
@@ -18,13 +18,13 @@ definitions:
 equations:
 
    arbitrage:
-      - chi*n^eta*c^sigma - w                      | 0 <= n <= inf
-      - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))   | 0 <= i <= inf
+      - chi*n^eta*c^sigma - w                         | 0 <= n <= inf
+      - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))     | 0 <= i <= inf
 
    arbitrage_exp:
-      - chi*n^eta*c^sigma - w   #                       | 0 <= n <= inf
-      - c^(-sigma) - m         #                | 0 <= i <=inf
-      
+      - chi*n^eta*c^sigma - w                         # | 0 <= n <= inf
+      - c^(-sigma) - m                                # | 0 <= i <=inf
+
    transition:
       - z = (1-rho)*zbar + rho*z(-1) + e_z
       - k = (1-delta)*k(-1) + i(-1)

--- a/examples/models/rbc_full.yaml
+++ b/examples/models/rbc_full.yaml
@@ -21,6 +21,10 @@ equations:
       - chi*n^eta*c^sigma - w                      | 0 <= n <= inf
       - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))   | 0 <= i <= inf
 
+   arbitrage_exp:
+      - chi*n^eta*c^sigma - w   #                       | 0 <= n <= inf
+      - c^(-sigma) - m         #                | 0 <= i <=inf
+      
    transition:
       - z = (1-rho)*zbar + rho*z(-1) + e_z
       - k = (1-delta)*k(-1) + i(-1)


### PR DESCRIPTION
- Added the indirect method solution for PEA. 
- Small fix to time_iteration: updating decision rule was before computation of the iteration error.
- Updated rbc_full.yaml file to include an arbitrage_exp section, so that it can be solved with the PEA

TODO: add a check for complementarity conditions/bounds for the controls. Merge the two functions (direct and indirect), since they differ on only one line. Do this by adding a switch so that when options are added later, can simply choose between direct and indirect. 