### PR TITLE
ENH: value function iteration in dtmscc and dtcscc [updated]

### DIFF
--- a/dolo/algos/dtcscc/value_iteration.py
+++ b/dolo/algos/dtcscc/value_iteration.py
@@ -152,7 +152,7 @@ from dolo.numeric.interpolation import create_interpolator
 from scipy.optimize import minimize
 
 
-def solve_policy(model, tol=1e-8, grid={}, distribution={}, integration_orders=None, maxit=100, maxit_howard=20, verbose=False, hook=None, initial_dr=None, pert_order=1):
+def solve_policy(model, tol=1e-6, grid={}, distribution={}, integration_orders=None, maxit=500, maxit_howard=500, verbose=False, hook=None, initial_dr=None, pert_order=1):
     """
     Solve for the value function and associated decision rule by iterating over
     the value function.
@@ -223,8 +223,7 @@ def solve_policy(model, tol=1e-8, grid={}, distribution={}, integration_orders=N
     values_0[:, :] = r0/(1-discount)
 
     if verbose:
-        headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'.format('N', ' Error',
-                                                               'Gain', 'Time')
+        headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'.format('N', ' Error','Gain', 'Time')
         stars = '-' * len(headline)
         print(stars)
         print(headline)

--- a/dolo/algos/dtcscc/vfi.py
+++ b/dolo/algos/dtcscc/vfi.py
@@ -1,12 +1,9 @@
 import time
 import warnings
-
 import numpy
-
 from dolo.numeric.discretization import gauss_hermite_nodes
 from dolo.numeric.interpolation.splines import MultivariateSplines
 from dolo.numeric.interpolation import create_interpolator
-
 
 def evaluate_policy(model, dr, tol=1e-8, grid={}, distribution={}, maxit=2000, verbose=False, hook=None,
                     integration_orders=None):
@@ -64,7 +61,7 @@ def evaluate_policy(model, dr, tol=1e-8, grid={}, distribution={}, maxit=2000, v
 
     if not integration_orders:
         integration_orders = [3] * sigma.shape[0]
-    [epsilons, weights] = gauss_hermite_nodes(integration_orders, sigma)
+    [nodes, weights] = gauss_hermite_nodes(integration_orders, sigma)
 
     if verbose:
         headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'.format('N', ' Error',
@@ -89,7 +86,7 @@ def evaluate_policy(model, dr, tol=1e-8, grid={}, distribution={}, maxit=2000, v
 
         # update the geuss of value functions
         guess = update_value(gfun, vfun, grid, controls, dr, drv,
-                             epsilons, weights, parms, n_vals)
+                             nodes, weights, parms, n_vals)
 
         # compute error
         err = abs(guess - guess_0).max()
@@ -100,8 +97,8 @@ def evaluate_policy(model, dr, tol=1e-8, grid={}, distribution={}, maxit=2000, v
         guess_0[:] = guess.copy()
 
         # print update to user, if verbose
-        t_finish = time.time()
-        elapsed = t_finish - t_start
+        t_end = time.time()
+        elapsed = t_end - t_start
         if verbose:
             print('|{0:4} | {1:10.3e} | {2:8.3f} | {3:8.3f} |'.format(
                 it, err, err_SA, elapsed))
@@ -118,18 +115,19 @@ def evaluate_policy(model, dr, tol=1e-8, grid={}, distribution={}, maxit=2000, v
     return drv
 
 
-def update_value(g, v, s, x, dr, drv, epsilons, weights, parms, n_vals):
+def update_value(g, v, s, x, dr, drv, nodes, weights, parms, n_vals):
 
     N = s.shape[0]
     n_s = s.shape[1]
     n_x = x.shape[1]
-    n_e = epsilons.shape[1]
+    n_e = nodes.shape[1]
 
     res = numpy.zeros((N, n_vals))
 
-    for i in range(epsilons.shape[0]):
+    # Compute expectation over future value function
+    for i in range(nodes.shape[0]):
 
-        e = epsilons[i, :]
+        e = nodes[i, :]
         w = weights[i]
 
         S = g(s, x, e, parms)
@@ -140,3 +138,287 @@ def update_value(g, v, s, x, dr, drv, epsilons, weights, parms, n_vals):
         res += w * v(s, x, S, X, V, parms)
 
     return res
+
+
+
+
+
+
+
+
+import time
+import numpy as np
+from dolo.algos.dtcscc.perturbations import approximate_controls
+from dolo.numeric.interpolation import create_interpolator
+from scipy.optimize import minimize
+
+
+def solve_policy(model, tol=1e-8, grid={}, distribution={}, integration_orders=None, maxit=100, verbose=False, hook=None, initial_dr=None, pert_order=1):
+    """
+    Solve for the value function and associated decision rule by iterating over
+    the value function.
+
+    Parameters:
+    -----------
+    model:
+        "dtcscc" model. Must contain a 'felicity' function.
+
+    Returns:
+    --------
+        dr : Markov decision rule
+            The solved decision rule/policy function
+        drv: decision rule
+            The solved value function
+    """
+
+    assert (model.model_type == 'dtcscc')
+
+    def vprint(t):
+        if verbose:
+            print(t)
+
+    # transition(s, x, e, p, out), felicity(s, x, p, out)
+    transition = model.functions['transition']
+    felicity = model.functions['felicity']
+    controls_lb = model.functions['controls_lb']
+    controls_ub = model.functions['controls_ub']
+
+    parms = model.calibration['parameters']
+    discount = model.calibration['beta']
+
+    x0 = model.calibration['controls']
+    s0 = model.calibration['states']
+    r0 = felicity(s0, x0, parms)
+
+    approx = model.get_grid(**grid)
+    # a = approx.a
+    # b = approx.b
+    # orders = approx.orders
+    distrib = model.get_distribution(**distribution)
+    sigma = distrib.sigma
+
+    # Possibly use the approximation orders?
+    if integration_orders is None:
+        integration_orders = [3] * sigma.shape[0]
+    [nodes, weights] = gauss_hermite_nodes(integration_orders, sigma)
+
+    interp_type = approx.interpolation
+    drv = create_interpolator(approx, interp_type)
+    if initial_dr is None:
+        if pert_order == 1:
+            dr = approximate_controls(model)
+        if pert_order > 1:
+            raise Exception("Perturbation order > 1 not supported (yet).")
+    else:
+        dr = initial_dr
+
+    grid = drv.grid
+    N = grid.shape[0]       # Number of states
+    n_x = grid.shape[1]     # Number of controls
+
+    controls = dr(grid)
+    controls_0 = np.zeros((N, n_x))
+    controls_0[:, :] = model.calibration['controls'][None, :]
+
+    values_0 = np.zeros((N, 1))
+    values_0[:, :] = r0/(1-discount)
+
+    if verbose:
+        headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'.format('N', ' Error',
+                                                               'Gain', 'Time')
+        stars = '-' * len(headline)
+        print(stars)
+        print(headline)
+        print(stars)
+
+    t1 = time.time()
+
+    # FIRST: value function iterations, 10 iterations to start
+    it = 0
+    err_v = 100
+    err_v_0 = 0.0
+    gain_v = 0.0
+    err_x = 100
+    err_x_0 = 100
+
+    if verbose:
+        print(stars)
+        print('Starting value function iteration')
+        print(stars)
+
+    while err_v > tol and it < 10:
+
+        t_start = time.time()
+        it += 1
+
+        # update interpolation object with current values
+        drv.set_values(values_0)
+
+        values = values_0.copy()
+        controls = controls_0.copy()
+
+        for n in range(N):
+            s = grid[n, :]
+            x = controls[n, :]
+            lb = controls_lb(s, parms)
+            ub = controls_ub(s, parms)
+            bnds = [e for e in zip(lb, ub)]
+
+            def valfun(xx):
+                return -choice_value(transition, felicity, s, xx, drv, nodes,
+                                     weights, parms, discount)[0]
+            res = minimize(valfun, x, bounds=bnds, tol=1e-4)
+
+            controls[n, :] = res.x
+            values[n, 0] = -valfun(res.x)
+
+        # compute error, update value and dr
+        err_x = abs(controls - controls_0).max()
+        err_v = abs(values - values_0).max()
+        t_end = time.time()
+        elapsed = t_end - t_start
+
+        values_0 = values
+        controls_0 = controls
+
+        gain_x = err_x / err_x_0
+        gain_v = err_v / err_v_0
+
+        err_x_0 = err_x
+        err_v_0 = err_v
+
+        # print update to user, if verbose
+        if verbose:
+            print('|{0:4} | {1:10.3e} | {2:8.3f} | {3:8.3f} |'.format(
+                it, err_v, gain_v, elapsed))
+
+    # SECOND: Howard improvement step, 10-20 iterations
+    it = 0
+    err_v = 100
+    err_v_0 = 0.0
+    gain_v = 0.0
+
+    if verbose:
+        print(stars)
+        print('Starting Howard improvement step')
+        print(stars)
+
+    while err_v > tol and it < 20:
+
+        t_start = time.time()
+        it += 1
+
+        # update interpolation object with current values
+        drv.set_values(values_0)
+
+        values = values_0.copy()
+        controls = controls_0.copy()
+        # controls = controls_0.copy()  # No need to keep updating
+
+        for n in range(N):
+            s = grid[n, :]
+            x = controls[n, :]
+            values[n, 0] = choice_value(transition, felicity, s, x, drv, nodes,
+                                        weights, parms, discount)[0]
+
+        # compute error, update value function
+        err_v = abs(values - values_0).max()
+        values_0 = values
+
+        t_end = time.time()
+        elapsed = t_end - t_start
+
+        gain_v = err_v / err_v_0
+        err_v_0 = err_v
+
+        # print update to user, if verbose
+        if verbose:
+            print('|{0:4} | {1:10.3e} | {2:8.3f} | {3:8.3f} |'.format(
+                it, err_v, gain_v, elapsed))
+
+    # THIRD: Back to value function iteration until convergence.
+    it = 0
+    err_v = 100
+    err_v_0 = 0.0
+    gain_v = 0.0
+    err_x = 100
+    err_x_0 = 100
+
+    if verbose:
+        print(stars)
+        print('Starting value function iteration')
+        print(stars)
+
+    while err_v > tol and it < maxit:
+
+        t_start = time.time()
+        it += 1
+
+        # update interpolation object with current values
+        drv.set_values(values_0)
+
+        values = values_0.copy()
+        controls = controls_0.copy()
+
+        for n in range(N):
+            s = grid[n, :]
+            x = controls[n, :]
+            lb = controls_lb(s, parms)
+            ub = controls_ub(s, parms)
+            bnds = [e for e in zip(lb, ub)]
+
+            def valfun(xx):
+                return -choice_value(transition, felicity, s, xx, drv, nodes,
+                                     weights, parms, discount)[0]
+            res = minimize(valfun, x, bounds=bnds, tol=1e-4)
+
+            controls[n, :] = res.x
+            values[n, 0] = -valfun(res.x)
+
+        # compute error, update value and dr
+        err_x = abs(controls - controls_0).max()
+        err_v = abs(values - values_0).max()
+        t_end = time.time()
+        elapsed = t_end - t_start
+
+        values_0 = values
+        controls_0 = controls
+
+        gain_x = err_x / err_x_0
+        gain_v = err_v / err_v_0
+
+        err_x_0 = err_x
+        err_v_0 = err_v
+
+        # print update to user, if verbose
+        if verbose:
+            print('|{0:4} | {1:10.3e} | {2:8.3f} | {3:8.3f} |'.format(
+                it, err_v, gain_v, elapsed))
+
+    if it == maxit:
+        warnings.warn(UserWarning("Maximum number of iterations reached"))
+
+    t2 = time.time()
+    if verbose:
+        print(stars)
+        print('Elapsed: {} seconds.'.format(t2 - t1))
+        print(stars)
+
+    # final value function and decision rule
+    drv.set_values(values_0)
+    dr = create_interpolator(approx, interp_type)
+    dr.set_values(controls_0)
+
+    return dr, drv
+
+
+def choice_value(transition, felicity, s, x, drv, nodes, weights, parms, beta):
+    cont_v = 0.0
+    for i in range(nodes.shape[0]):
+        e = nodes[i, :]
+        w = weights[i]
+        S = transition(s, x, e, parms)
+        # X = dr(S)
+        V = drv(S)[0]
+        cont_v += w*V
+    return felicity(s, x, parms) + beta*cont_v

--- a/dolo/algos/dtcscc/vfi.py
+++ b/dolo/algos/dtcscc/vfi.py
@@ -64,8 +64,7 @@ def evaluate_policy(model, dr, tol=1e-8, grid={}, distribution={}, maxit=2000, v
     [nodes, weights] = gauss_hermite_nodes(integration_orders, sigma)
 
     if verbose:
-        headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'.format('N', ' Error',
-                                                               'Gain', 'Time')
+        headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'.format('N', ' Error', 'Gain', 'Time')
         stars = '-' * len(headline)
         print(stars)
         print(headline)

--- a/dolo/algos/dtcscc/vfi.py
+++ b/dolo/algos/dtcscc/vfi.py
@@ -153,7 +153,7 @@ from dolo.numeric.interpolation import create_interpolator
 from scipy.optimize import minimize
 
 
-def solve_policy(model, tol=1e-8, grid={}, distribution={}, integration_orders=None, maxit=100, verbose=False, hook=None, initial_dr=None, pert_order=1):
+def solve_policy(model, tol=1e-8, grid={}, distribution={}, integration_orders=None, maxit=100, maxit_howard=20, verbose=False, hook=None, initial_dr=None, pert_order=1):
     """
     Solve for the value function and associated decision rule by iterating over
     the value function.
@@ -303,7 +303,7 @@ def solve_policy(model, tol=1e-8, grid={}, distribution={}, integration_orders=N
         print('Starting Howard improvement step')
         print(stars)
 
-    while err_v > tol and it < 20:
+    while err_v > tol and it < maxit_howard:
 
         t_start = time.time()
         it += 1

--- a/dolo/algos/dtmscc/value_iteration.py
+++ b/dolo/algos/dtmscc/value_iteration.py
@@ -1,4 +1,270 @@
+import time
+import numpy as np
+import scipy.optimize
+from collections import OrderedDict
+
+class IterationsPrinter:
+
+    def __init__(self, *knames, verbose=False):
+        knames = OrderedDict(knames)
+        names = []
+        types = []
+        fmts = []
+        for k, v in knames.items():
+            names.append(k)
+            types.append(v)
+            if v == int:
+                fmts.append("{:4}")
+            elif v == float:
+                fmts.append("{:9.3e}")
+        fmt_str = "| " + str.join(' | ', fmts) + " |"
+        self.verbose = verbose
+        self.names = names
+        self.types = types
+        self.fmts = fmts
+        self.width = len( fmt_str.format(*[0 for i in self.names]) )
+        self.fmt_str = fmt_str
+        self.t_start = time.time()
+
+
+    def print_line(self):
+        if not self.verbose:
+            return
+        print("-"*self.width)
+
+    def print_header(self, msg=None):
+        if not self.verbose:
+            return
+        self.print_line()
+        if msg is not None:
+            ll = '| ' + msg
+            print(ll + ' '*(self.width-len(ll)-1) + '|')
+            self.print_line()
+        title_str = ''
+        for i, v in enumerate(self.types):
+            k = self.names[i]
+            if v == int:
+                title_str += " {:4} |".format(k)
+            elif v == float:
+                title_str += " {:9} |".format(k)
+        title_str = '|' + title_str
+        print(title_str)
+        self.print_line()
+
+    def print_iteration(self, **args):
+        if not self.verbose:
+            return
+        vals = [args[k] for k in self.names]
+        print(self.fmt_str.format(*vals))
+
+    def print_finished(self):
+        if not self.verbose:
+            return
+        elapsed = time.time() - self.t_start
+        line = '| Elapsed: {:.2f} seconds.'.format(elapsed)
+        self.print_line()
+        print(line + ' '*(self.width-len(line)-1) + '|')
+        self.print_line()
+        print()
+
+
 import numpy
+from dolo.numeric.decision_rules_markov import
+
+def solve_policy(model, grid={}, tol=1e-4, maxit=500, verbose=True):
+        """
+        Solve for the value function and associated Markov decision rule by iterating over
+        the value function.
+
+        Parameters:
+        -----------
+        model :
+            "dtmscc" model. Must contain a 'felicity' function.
+        grid :
+            grid options
+        dr :
+            decision rule to evaluate
+
+        Returns:
+        --------
+        mdr : Markov decision rule
+            The solved decision rule/policy function
+        mdrv: decision rule
+            The solved value function
+        """
+
+    assert(model.model_type == 'dtmscc')
+
+    def vprint(t):
+        if verbose:
+            print(t)
+    #assert(set(['g','r']).issubset(set(model.model_spec)))
+
+
+    transition = model.functions['transition']
+    felicity = model.functions['felicity']
+    controls_lb = model.functions['controls_lb']
+    controls_ub = model.functions['controls_ub']
+
+    parms = model.calibration['parameters']
+    discount = model.calibration['beta']
+
+    x0 = model.calibration['controls']
+    m0 = model.calibration['markov_states']
+    s0 = model.calibration['states']
+    r0 = felicity(m0, s0, x0, parms)
+
+    [P, Q] = model.markov_chain
+    n_ms = P.shape[0]   # number of markov states
+
+    approx = model.get_grid(**grid)
+    a = approx.a
+    b = approx.b
+    orders = approx.orders
+
+    MarkovDecisionRule
+    mdrv = MarkovDecisionRule(n_ms, a, b, orders)  # values
+
+    grid = mdrv.grid
+    N = grid.shape[0]
+    n_x = len(x0)
+
+    controls_0 = np.zeros((n_ms, N, n_x))
+    controls_0[:, :, :] = model.calibration['controls'][None, None, :]
+    #
+    values_0 = np.zeros((n_ms, N, 1))
+    values_0[:, :, :] = r0/(1-discount)
+
+    itprint = IterationsPrinter(('N', int), ('Error', float), ('Gain', float), ('Time', float), verbose=verbose)
+    itprint.print_header('Evaluating value of initial guess')
+
+    # Reset counters
+    it = 0
+    err_v = 100
+    err_v_0 = 0.0
+    gain_v = 1.0
+
+    # Iterating over value function using the same decision rule
+    while it < maxit and err_v > tol:
+
+        t_start = time.time()
+        it += 1
+
+        # update interpolation object with current values
+        mdrv.set_values(values_0)
+        values = values_0.copy()
+
+        for i_m in range(n_ms):
+            for n in range(N):
+                m = P[i_m, :]
+                s = grid[n, :]
+                x = controls_0[i_m, n, :]
+                values[i_m, n, 0] = choice_value(transition, felicity, i_m, s, x, mdrv, P, Q, parms, discount)
+
+        # compute error, update value function
+        err_v = abs(values - values_0).max()
+        values_0 = values
+
+        t_end = time.time()
+        elapsed = t_end-t_start
+
+        gain_v = err_v / err_v_0
+        err_v_0 = err_v
+        itprint.print_iteration(N=it, Error=err_v, Gain=gain_v, Time=elapsed)
+        # vprint(fmt_str.format(it, err_v, gain_v, elapsed))
+
+    itprint.print_finished()
+
+
+    itprint = IterationsPrinter(('N', int), ('Error_V', float), ('Gain_V', float),
+                                ('Error_x', float), ('Gain_x', float), ('Time', float), verbose=verbose)
+    itprint.print_header('Start value function iterations.')
+
+    if verbose:
+        print('Finished iterating on value function only. Starting value with policy iteration.')
+
+    # Reset counters
+    it = 0
+    err_v = 100
+    err_v_0 = 0.0
+    gain_v = 0.0
+    err_x = 100
+    err_x_0 = 100
+
+    # Optimization: update decision rule, as well as value function
+    while it < maxit and err_v > tol:
+
+        t_start = time.time()
+        it += 1
+
+        # update interpolation object with current values
+        mdrv.set_values(values_0)
+
+        values = values_0.copy()
+        controls = controls_0.copy()
+
+        for i_m in range(n_ms):
+            for n in range(N):
+                m = P[i_m, :]
+                s = grid[n, :]
+                x = controls[i_m, n, :]
+                lb = controls_lb(m, s, parms)
+                ub = controls_ub(m, s, parms)
+                bnds = [e for e in zip(lb, ub)]
+
+                def valfun(xx):
+                    return -choice_value(transition, felicity, i_m, s, xx, mdrv, P, Q, parms, discount)[0]
+                res = scipy.optimize.minimize(valfun, x, bounds=bnds)
+
+                controls[i_m, n, :] = res.x
+                values[i_m, n, 0] = -valfun(res.x)
+
+        # compute error, update value and dr
+        err_x = abs(controls - controls_0).max()
+        err_v = abs(values - values_0).max()
+        t_end = time.time()
+        elapsed = t_end-t_start
+
+        values_0 = values
+        controls_0 = controls
+
+        gain_x = err_x / err_x_0
+        gain_v = err_v / err_v_0
+
+        err_x_0 = err_x
+        err_v_0 = err_v
+
+        itprint.print_iteration(N=it,
+                                Error_V=err_v,
+                                Gain_V=gain_v,
+                                Error_x=err_x,
+                                Gain_x=gain_x,
+                                Time=elapsed)
+
+    # final value function and decision rule
+    mdr = MarkovDecisionRule(n_ms, a, b, orders)  # values
+    mdr.set_values(controls)
+    mdrv.set_values(values_0)
+
+    itprint.print_finished()
+
+    return mdr, mdrv
+
+
+def choice_value(transition, felicity, i_ms, s, x, drv, P, Q, parms, beta):
+
+    n_ms = P.shape[0]   # number of markov states
+    m = P[i_ms, :]
+    cont_v = 0.0
+    for I_ms in range(n_ms):
+        M = P[I_ms, :]
+        prob = Q[i_ms, I_ms]
+        S = transition(m, s, x, M, parms)
+        V = drv(I_ms, S)[0]
+        cont_v += prob*V
+    return felicity(m, s, x, parms) + beta*cont_v
+
+
 
 def evaluate_policy(model, mdr, tol=1e-8,  maxit=2000, grid={}, verbose=True, initial_guess=None, hook=None, integration_orders=None):
 
@@ -47,38 +313,25 @@ def evaluate_policy(model, mdr, tol=1e-8,  maxit=2000, grid={}, verbose=True, in
     grid = mdrv.grid
     N = grid.shape[0]
 
-    controls = numpy.zeros((n_ms, N, n_x))
+    controls = np.zeros((n_ms, N, n_x))
     for i_m in range(n_ms):
-        controls[i_m,:,:] = mdr(i_m,grid) #x0[None,:]
+        controls[i_m, :, :] = mdr(i_m, grid) #x0[None,:]
 
-    values_0 = numpy.zeros((n_ms, N, n_v))
+    values_0 = np.zeros((n_ms, N, n_v))
     if initial_guess is None:
         for i_m in range(n_ms):
-            values_0[i_m,:,:] = v0[None,:]
+            values_0[i_m, :, :] = v0[None, :]
     else:
         for i_m in range(n_ms):
-            values_0[i_m,:,:] = initial_guess(i_m, grid)
+            values_0[i_m, :, :] = initial_guess(i_m, grid)
 
-
-    ff = model.functions['arbitrage']
-    gg = model.functions['transition']
-    aa = model.functions['auxiliary']
-    vaval = model.functions['value']
-
-
-    f = lambda m,s,x,M,S,X,p: ff(m,s,x,M,S,X,p)
-    g = lambda m,s,x,M,p: gg(m,s,x,M,p)
-    def val(m,s,x,v,M,S,X,V,p):
-        return vaval(m,s,x,v,M,S,X,V,p)
-    # val = lambda m,s,x,v,M,S,X,V,p: vaval(m,s,x,aa(m,s,x,p),v,M,S,X,aa(M,S,X,p),V,p)
-
+    val = model.functions['value']
 
     sh_v = values_0.shape
 
     err = 10
     inner_maxit = 50
     it = 0
-
 
     if verbose:
         headline = '|{0:^4} | {1:10} | {2:8} | {3:8} |'.format( 'N',' Error', 'Gain','Time')
@@ -87,10 +340,9 @@ def evaluate_policy(model, mdr, tol=1e-8,  maxit=2000, grid={}, verbose=True, in
         print(headline)
         print(stars)
 
-    import time
     t1 = time.time()
 
-    err_0 = numpy.nan
+    err_0 = np.nan
 
     verbit = (verbose == 'full')
 
@@ -136,27 +388,27 @@ def update_value(val, g, s, x, v, dr, drv, P, Q, parms):
 
     n_ms = P.shape[0]   # number of markov states
 
-    res = numpy.zeros_like(v)
+    res = np.zeros_like(v)
 
     for i_ms in range(n_ms):
 
-        m = P[i_ms,:][None,:].repeat(N,axis=0)
+        m = P[i_ms, :][None, :].repeat(N, axis=0)
 
-        xm = x[i_ms,:,:]
-        vm = v[i_ms,:,:]
+        xm = x[i_ms, :, :]
+        vm = v[i_ms, :, :]
 
         for I_ms in range(n_ms):
 
             # M = P[I_ms,:][None,:]
-            M = P[I_ms,:][None,:].repeat(N,axis=0)
+            M = P[I_ms, :][None, :].repeat(N, axis=0)
             prob = Q[i_ms, I_ms]
 
             S = g(m, s, xm, M, parms)
             XM = dr(I_ms, S)
             VM = drv(I_ms, S)
 
-            rr = val(m,s,xm,vm,M,S,XM,VM,parms)
+            rr = val(m, s, xm, vm, M, S, XM, VM, parms)
 
-            res[i_ms,:,:] += prob*rr
+            res[i_ms, :, :] += prob*rr
 
     return res

--- a/dolo/algos/dtmscc/value_iteration.py
+++ b/dolo/algos/dtmscc/value_iteration.py
@@ -71,7 +71,8 @@ class IterationsPrinter:
 import numpy
 from dolo.numeric.decision_rules_markov import MarkovDecisionRule
 
-def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=True):
+def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20,
+                 verbose=True):
     """
     Solve for the value function and associated Markov decision rule by iterating over
     the value function.
@@ -95,9 +96,9 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=T
 
     assert(model.model_type == 'dtmscc')
 
-    def vprint(t):
-        if verbose:
-            print(t)
+    # def vprint(t):
+    #     if verbose:
+    #         print(t)
     # assert(set(['g','r']).issubset(set(model.model_spec)))
 
     transition = model.functions['transition']
@@ -134,7 +135,8 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=T
     values_0 = np.zeros((n_ms, N, 1))
     values_0[:, :, :] = r0/(1-discount)
 
-    itprint = IterationsPrinter(('N', int), ('Error', float), ('Gain', float), ('Time', float), verbose=verbose)
+    itprint = IterationsPrinter(('N', int), ('Error', float), ('Gain', float),
+                                ('Time', float), verbose=verbose)
     itprint.print_header('Evaluating value of initial guess')
 
     # FIRST: value function iterations, 10 iterations to start
@@ -171,7 +173,8 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=T
                 bnds = [e for e in zip(lb, ub)]
 
                 def valfun(xx):
-                    return -choice_value(transition, felicity, i_m, s, xx, mdrv, P, Q, parms, discount)[0]
+                    return -choice_value(transition, felicity, i_m, s, xx,
+                                         mdrv, P, Q, parms, discount)[0]
                 res = scipy.optimize.minimize(valfun, x, bounds=bnds)
 
                 controls[i_m, n, :] = res.x
@@ -192,11 +195,7 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=T
         err_x_0 = err_x
         err_v_0 = err_v
 
-        itprint.print_iteration(N=it,
-                                Error_V=err_v,
-                                Gain_V=gain_v,
-                                Error_x=err_x,
-                                Gain_x=gain_x,
+        itprint.print_iteration(N=it, Error=err_v, Gain=gain_v,
                                 Time=elapsed)
 
     # SECOND: Howard improvement step, 10-20 iterations
@@ -237,7 +236,6 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=T
         err_v_0 = err_v
         itprint.print_iteration(N=it, Error=err_v, Gain=gain_v, Time=elapsed)
         # vprint(fmt_str.format(it, err_v, gain_v, elapsed))
-
 
     # THIRD: value function iterations until convergence
     it = 0
@@ -295,13 +293,9 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=T
         err_v_0 = err_v
 
         itprint.print_iteration(N=it,
-                                Error_V=err_v,
-                                Gain_V=gain_v,
-                                Error_x=err_x,
-                                Gain_x=gain_x,
+                                Error=err_v,
+                                Gain=gain_v,
                                 Time=elapsed)
-
-
 
     itprint.print_finished()
 
@@ -310,8 +304,8 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20, verbose=T
                                 ('Error_x', float), ('Gain_x', float), ('Time', float), verbose=verbose)
     itprint.print_header('Start value function iterations.')
 
-    if verbose:
-        print('Finished iterating on value function only. Starting value with policy iteration.')
+    # if verbose:
+    #     print('Finished iterating on value function only. Starting value with policy iteration.')
 
     # final value function and decision rule
     mdr = MarkovDecisionRule(n_ms, a, b, orders)  # values

--- a/dolo/algos/dtmscc/value_iteration.py
+++ b/dolo/algos/dtmscc/value_iteration.py
@@ -71,8 +71,8 @@ class IterationsPrinter:
 import numpy
 from dolo.numeric.decision_rules_markov import MarkovDecisionRule
 
-def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20,
-                 verbose=True):
+def solve_policy(model, grid={}, tol=1e-6, maxit=500,
+                 maxit_howard=20, verbose=False):
     """
     Solve for the value function and associated Markov decision rule by iterating over
     the value function.
@@ -95,11 +95,6 @@ def solve_policy(model, grid={}, tol=1e-4, maxit=500, maxit_howard=20,
     """
 
     assert(model.model_type == 'dtmscc')
-
-    # def vprint(t):
-    #     if verbose:
-    #         print(t)
-    # assert(set(['g','r']).issubset(set(model.model_spec)))
 
     transition = model.functions['transition']
     felicity = model.functions['felicity']

--- a/dolo/compiler/recipes.yaml
+++ b/dolo/compiler/recipes.yaml
@@ -2,7 +2,7 @@ dtcscc:
 
     model_spec: dtcscc
 
-    symbols: ['states', 'controls', 'expectations', 'values', 'shocks', 'parameters']
+    symbols: ['states', 'controls', 'rewards', 'expectations', 'values', 'shocks', 'parameters']
 
     specs:
 
@@ -74,6 +74,18 @@ dtcscc:
                 - ['expectations', 0, 'z']
                 - ['parameters',0,'p']
 
+        felicity:
+
+            optional: True
+            recursive: True
+            target: ['rewards', 0, 'r']
+
+            eqs:
+                - ['states',0,'s']
+                - ['controls',0,'x']
+                - ['parameters',0,'p']
+
+
         arbitrage_exp:
 
             optional: True
@@ -91,7 +103,7 @@ dtmscc:
 
     model_spec: dtmscc
 
-    symbols: ['markov_states', 'states', 'controls', 'values', 'expectations', 'shocks', 'parameters']
+    symbols: ['markov_states', 'states', 'controls', 'rewards', 'values', 'expectations', 'shocks', 'parameters']
 
     specs:
 
@@ -118,7 +130,6 @@ dtmscc:
                     - ['parameters', 0, 'p']
 
                 middle: ['controls', 0, 's']
-
 
 
         transition:
@@ -178,18 +189,29 @@ dtmscc:
                 - ['expectations', 0, 'z']
                 - ['parameters',0,'p']
 
-        arbitrage_exp:
+        felicity:
 
             optional: True
+            recursive: True
+
+            target: ['rewards', 0,'r']
 
             eqs:
                 - ['markov_states',0,'m']
                 - ['states',0,'s']
                 - ['controls',0,'x']
-                - ['expectations', 0, 'z']
-                #- ['auxiliaries',0,'y']
                 - ['parameters', 0, 'p']
 
+
+        arbitrage_exp:
+
+            optional: True
+
+            eqs:
+                - ['states',0,'s']
+                - ['controls',0,'x']
+                #- ['auxiliaries',0,'y']
+                - ['parameters', 0, 'p']
 
 dynare:
 

--- a/examples/models/rbc_dtmscc.yaml
+++ b/examples/models/rbc_dtmscc.yaml
@@ -21,7 +21,7 @@ equations:
 
    arbitrage:
       - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))     | 0.0 <= i <= inf
-      - chi*n^eta*c^sigma - w                         | 0.0 <= n <= inf
+      - chi*n^eta*c^sigma - w                         | 0.0001 <= n <= inf
 
    felicity:
        - u =  c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta)

--- a/examples/models/rbc_dtmscc.yaml
+++ b/examples/models/rbc_dtmscc.yaml
@@ -6,6 +6,7 @@ symbols:
    markov_states: [z]
    states:  [k]
    controls: [i, n]
+   rewards: [u]
    parameters: [beta, sigma, eta, chi, delta, alpha, rho, zbar, sig_z, kmax]
 
 definitions:
@@ -22,6 +23,9 @@ equations:
       - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))     | 0.0 <= i <= inf
       - chi*n^eta*c^sigma - w                         | 0.0 <= n <= inf
 
+   felicity:
+       - u =  c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta)
+
 calibration:
 
     #parameters:
@@ -32,7 +36,7 @@ calibration:
     delta : 0.025
     alpha : 0.33
     rho : 0.8
-    sigma: 1.0
+    sigma: 2.0
     eta: 1.0
     zbar: 1.0
     sig_z: 0.001**2
@@ -46,6 +50,7 @@ calibration:
     k: n/(rk/alpha)^(1/(1-alpha))
     i: delta*k
     c: z*k^alpha*n^(1-alpha) - i
+    u: c^(1-sigma)/(1-sigma)  - chi*n^(1+eta)/(1+eta)
 
 options:
 
@@ -59,3 +64,4 @@ options:
         a: [5.0]
         b: [30.0]
         orders: [20]
+        mu: 3

--- a/examples/models/rbc_vfi.yaml
+++ b/examples/models/rbc_vfi.yaml
@@ -1,0 +1,68 @@
+name: Real Business Cycle
+
+model_type: dtcscc
+
+symbols:
+
+   states:  [z, k]
+   controls: [i, n]
+   rewards: [u]
+   shocks: [e_z]
+   parameters: [beta, sigma, eta, chi, delta, alpha, rho, zbar, sig_z ]
+
+definitions:
+    y: z*k^alpha*n^(1-alpha)
+    c: y - i
+    rk: alpha*y/k
+    w: (1-alpha)*y/n
+
+equations:
+
+    arbitrage:
+        - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))  | 0 <= i <= 1000
+        - chi*n^eta*c^sigma - w                      | 0 <= n <= 1000
+
+
+    transition:
+        - z = (1-rho)*zbar + rho*z(-1) + e_z
+        - k = (1-delta)*k(-1) + i(-1)
+
+    felicity:
+        - u = c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta)
+
+calibration:
+
+    # parameters
+    beta : 0.99
+    phi: 1
+    delta : 0.025
+    alpha : 0.33
+    rho : 0.8
+    sigma: 2
+    eta: 1
+    sig_z: 0.016
+    zbar: 1
+    chi : w/c^sigma/n^eta
+    c_i: 1.5
+    c_y: 0.5
+
+    # endogenous variables
+    n: 0.33
+    k: n/(rk/alpha)^(1/(1-alpha))
+    w: (1-alpha)*z*(k/n)^(alpha)
+    i: delta*k
+    y: z*k^alpha*n^(1-alpha)
+    c: y - i
+    z: zbar
+    rk: 1/beta-1+delta
+    u: c^(1-sigma)/(1-sigma) - chi*n^(1+eta)/(1+eta)
+
+options:
+
+    distribution: !Normal
+        sigma: [ [ sig_z**2] ]
+
+    grid: !Cartesian
+        a: [ 1-2*sig_z, k*0.9 ]
+        b: [ 1+2*sig_z, k*1.1 ]
+        orders: [3, 20]

--- a/examples/models/rbc_vfi.yaml
+++ b/examples/models/rbc_vfi.yaml
@@ -8,7 +8,7 @@ symbols:
    controls: [i, n]
    rewards: [u]
    shocks: [e_z]
-   parameters: [beta, sigma, eta, chi, delta, alpha, rho, zbar, sig_z ]
+   parameters: [beta, sigma, eta, chi, delta, alpha, rho, zbar, sig_z]
 
 definitions:
     y: z*k^alpha*n^(1-alpha)
@@ -19,8 +19,8 @@ definitions:
 equations:
 
     arbitrage:
-        - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))  | 0 <= i <= 1000
-        - chi*n^eta*c^sigma - w                      | 0 <= n <= 1000
+        - 1 - beta*(c/c(1))^(sigma)*(1-delta+rk(1))  | 0 <= i <= inf
+        - chi*n^eta*c^sigma - w                      | 0.0001 <= n <= inf
 
 
     transition:
@@ -43,8 +43,6 @@ calibration:
     sig_z: 0.016
     zbar: 1
     chi : w/c^sigma/n^eta
-    c_i: 1.5
-    c_y: 0.5
 
     # endogenous variables
     n: 0.33


### PR DESCRIPTION
Adding true value function iteration algorithm, in both dtmscc and dtcscc modes. This replaces the previous pull request ([#102](https://github.com/EconForge/dolo/pull/102)), as have worked out the problem I was facing previously. First, the updates are:

* The dtmscc version works from @albop's vfi branch, tidying and fixing small issues.
* The dtcscc version works from the dtmscc version.
* Ordering inside the algorithm is: VFI 10 steps --> Howard improvement 20 steps (user able to change this) --> VFI until convergence.
* It would be nice to make the VFI and Howard code chunks into stand alone functions that could easily be called repeatedly, rather than hard-coded in as "1-2-1"

### Remaining (smaller) problem

In PR [#102](https://github.com/EconForge/dolo/pull/102) I noted there were convergence issues. After playing around, it seems that the convergence issue is coming from the non-linear solver step. Specifically, the solver seems to generate problems when the bounds on some controls are infinite or lead to division-by-zero problems. For example, in the standard RBC example, if you use the bounds on labour supply, 0<= n <= n_large, the solver seems to want to use the lower bound, and this generates the divergence discussed in [#102](https://github.com/EconForge/dolo/pull/102). 

This may mean that we need to: 
* move to a solver that handles boundary conditions better. @albop notes that we may be able to use numba to pass the function to be solved to a C library... 
* Leave a note in the documentation pointing out that you need to be careful with boundary conditions.   

