### PR TITLE
ENH: add printing of model definitions 

### DIFF
--- a/dolo/compiler/model_numeric.py
+++ b/dolo/compiler/model_numeric.py
@@ -129,7 +129,7 @@ file: "{filename}\n'''.format(**self.infos)
         definitions = self.symbolic.definitions
         tmp = []
         for deftype in definitions:
-            tmp.append(deftype + '=' + definitions[deftype])
+            tmp.append(deftype + ' = ' + definitions[deftype])
         definitions = {'definitions': tmp}
         equations.update(definitions)
 
@@ -144,18 +144,21 @@ file: "{filename}\n'''.format(**self.infos)
                 # Update the residuals section with the right number of empty
                 # values. Note: adding 'zeros' was easiest (rather than empty
                 # cells), since other variable types have  arrays of zeros.
-                res.update({'definitions': zeros(len(eqlist))})
+                res.update({'definitions': [None for i in range(len(eqlist))]})
             else:
                 eqlist = equations[eqgroup]
             ss += u"{}\n".format(eqgroup)
             for i, eq in enumerate(eqlist):
                 val = res[eqgroup][i]
-                if abs(val) < 1e-8:
-                    val = 0
-                vals = '{:.4f}'.format(val)
-                if abs(val) > 1e-8:
-                    vals = colored(vals, 'red')
-                ss += u" {eqn:2} : {vals} : {eqs}\n".format(eqn=str(i+1), vals=vals, eqs=eq)
+                if val is None:
+                    ss += u" {eqn:2} : {eqs}\n".format(eqn=str(i+1), eqs=eq)
+                else:
+                    if abs(val) < 1e-8:
+                        val = 0
+                    vals = '{:.4f}'.format(val)
+                    if abs(val) > 1e-8:
+                        vals = colored(vals, 'red')
+                    ss += u" {eqn:2} : {vals} : {eqs}\n".format(eqn=str(i+1), vals=vals, eqs=eq)
             ss += "\n"
         s += ss
 
@@ -198,7 +201,7 @@ file: "{filename}\n'''.format(**self.infos)
             definitions = self.symbolic.definitions
             tmp = []
             for deftype in definitions:
-                tmp.append(deftype + '=' + definitions[deftype])
+                tmp.append(deftype + ' = ' + definitions[deftype])
             definitions = {'definitions': tmp}
             equations.update(definitions)
 
@@ -212,7 +215,7 @@ file: "{filename}\n'''.format(**self.infos)
                 eq = equations[eq_type][i]
                 # if eq_type in ('expectation','direct_response'):
                 #     vals = ''
-                if eq_type not in ('arbitrage', 'transition'):
+                if eq_type not in ('arbitrage', 'transition', 'arbitrage_exp'):
                     vals = ''
                 else:
                     val = resids[eq_type][i]

--- a/dolo/compiler/model_numeric.py
+++ b/dolo/compiler/model_numeric.py
@@ -113,7 +113,7 @@ class NumericModel:
     def __str__(self):
 
         from dolo.misc.termcolor import colored
-
+        from numpy import zeros
         s = u'''
 Model:
 ------
@@ -123,15 +123,30 @@ file: "{filename}\n'''.format(**self.infos)
 
         ss = '\nEquations:\n----------\n\n'
         res = self.residuals()
+        res.update({'definitions': zeros(1)})
+
+        equations = self.symbolic.equations
+        definitions = self.symbolic.definitions
+        tmp = []
+        for deftype in definitions:
+            tmp.append(deftype + '=' + definitions[deftype])
+        definitions = {'definitions': tmp}
+        equations.update(definitions)
 
         # for eqgroup, eqlist in self.symbolic.equations.items():
         for eqgroup in res.keys():
             if eqgroup == 'auxiliary':
                 continue
             if eqgroup == 'dynare':
-                eqlist = self.symbolic.equations
+                eqlist = equations
+            if eqgroup == 'definitions':
+                eqlist = equations[eqgroup]
+                # Update the residuals section with the right number of empty
+                # values. Note: adding 'zeros' was easiest (rather than empty
+                # cells), since other variable types have  arrays of zeros.
+                res.update({'definitions': zeros(len(eqlist))})
             else:
-                eqlist = self.symbolic.equations[eqgroup]
+                eqlist = equations[eqgroup]
             ss += u"{}\n".format(eqgroup)
             for i, eq in enumerate(eqlist):
                 val = res[eqgroup][i]

--- a/dolo/compiler/model_numeric.py
+++ b/dolo/compiler/model_numeric.py
@@ -179,6 +179,14 @@ file: "{filename}\n'''.format(**self.infos)
             equations = {"dynare": self.symbolic.equations}
         else:
             equations = self.symbolic.equations
+            # Create definitions equations and append to equations dictionary
+            definitions = self.symbolic.definitions
+            tmp = []
+            for deftype in definitions:
+                tmp.append(deftype + '=' + definitions[deftype])
+            definitions = {'definitions': tmp}
+            equations.update(definitions)
+
         variables = sum([e for k,e in self.symbols.items() if k != 'parameters'], [])
         table = "<tr><td><b>Type</b></td><td><b>Equation</b></td><td><b>Residual</b></td></tr>\n"
 
@@ -187,7 +195,9 @@ file: "{filename}\n'''.format(**self.infos)
             eq_lines = []
             for i in range(len(equations[eq_type])):
                 eq = equations[eq_type][i]
-                if eq_type in ('expectation','direct_response'):
+                # if eq_type in ('expectation','direct_response'):
+                #     vals = ''
+                if eq_type not in ('arbitrage', 'transition'):
                     vals = ''
                 else:
                     val = resids[eq_type][i]
@@ -199,7 +209,7 @@ file: "{filename}\n'''.format(**self.infos)
                     # keep only lhs for now
                     eq, comp = str.split(eq,'|')
                 lat = eq2tex(variables, eq)
-                lat =  '${}$'.format(lat)
+                lat = '${}$'.format(lat)
                 line = [lat, vals]
                 h = eq_type if i==0 else ''
                 fmt_line = '<tr><td>{}</td><td>{}</td><td>{}</td></tr>'.format(h, *line)

--- a/examples/models/NK_dsge.yaml
+++ b/examples/models/NK_dsge.yaml
@@ -1,0 +1,75 @@
+name: New Keynesian DSGE
+
+model_type: dtcscc
+
+symbols:
+
+  states: [Delta__L, a, cp]
+  controls: [c, n, F1, F2]
+  expectations: [m1]
+  shocks: [u__a, u__tau]
+  parameters: [beta, psi, epsilon, phi, theta, tau, chi, sig_a, rho__a, rho__tau, sig_tau]
+
+definitions:
+
+      pi: ((1-(F1/F2)^(1-epsilon)*(1-theta))/theta)^(1/(epsilon-1))
+      r: (1/beta)*(pi)^phi
+      rw: chi*(n)^psi*(c)
+      mc: (1-tau*exp(cp))*(rw)/(exp(a))
+      Delta: theta*(pi)^epsilon*Delta__L+(1-theta)*((F1)/(F2))^(-epsilon)
+
+equations:
+
+  arbitrage:
+    - 1/c-beta*r/(c(1)*pi(1))
+    - (epsilon/(epsilon-1))*mc + theta*beta*pi(1)^epsilon*F1(1)-F1
+    - 1+theta*beta*pi(1)^(epsilon-1)*F2(1)-F2
+    - c-exp(a)/Delta*n
+
+  transition:
+    - Delta__L=Delta(-1)
+    - a=rho__a*a(-1)+u__a
+    - cp=rho__tau*cp(-1)+u__tau
+
+calibration:
+
+  # parameters calibration
+  beta: .995
+  psi: 1 #1.0
+  epsilon: 11
+  phi: 1.5
+  theta: .4
+  tau: 1/epsilon
+  chi: 1.0
+  sig_a: .0025
+  rho__a: .9
+  sig_tau: .025
+  rho__tau: 0
+
+
+  # variable steady states / initial conditions
+  pi: 1
+  r: 1/beta
+  Delta: 1
+  Delta__L: Delta
+  n: 1
+  c: 1
+  mc: (1-tau)*(rw)/(exp(a))
+  y: 1
+  F1:  (epsilon/(epsilon-1))*mc/(1-theta*beta*((pi))^epsilon)
+  F2:  1/(1-theta*beta*((pi)^(epsilon-1)))
+  a: 0
+  u__a: 0
+  cp: 0
+  u__tau: 0
+
+
+options:
+
+  distribution: !Normal
+    sigma: [[sig_a^2, 0], [0, sig_tau^2]]
+
+  grid: !CartesianGrid
+    a: [1, -3*((sig_a^2)/(1-rho__a^2))^.5, -3*sig_tau]
+    b: [1.05,  3*((sig_a^2)/(1-rho__a^2))^.5, 3*sig_tau]
+    orders: [20, 20, 20]


### PR DESCRIPTION
When a model yaml file is imported, the model can be called, which typically prints the arbitrage and transition equations. This call now prints the model definitions. (Note, the definition equations are not solved, and so there are no associated residual values, so the residuals column is left blank). 

We could also add the printing of model symbols (e.g. states, controls) or complementarity conditions/constraints.

This is a (partial) response to issue [#92](https://github.com/EconForge/dolo/issues/92).

