### PR TITLE
FIX: small fix to the quadrature routine, plus some short documentation

### DIFF
--- a/dolo/numeric/discretization/quadrature.py
+++ b/dolo/numeric/discretization/quadrature.py
@@ -29,7 +29,7 @@ def hermgauss(n):
             z = 1.91*z+0.91*x[1]
         else:
             z = 2*z+x[i-2]
-    # root finding iterations 
+    # root finding iterations
         its = 0
         while its<maxit:
             its += 1
@@ -52,12 +52,30 @@ def hermgauss(n):
         w[n-i-1] = w[i]
 
     return [x,w]
- 
+
 
 
 
 def gauss_hermite_nodes(orders, sigma, mu=None):
+    '''
+    Computes the weights and nodes for Gauss Hermite quadrature.
+    
+    Parameters
+    ----------
+    orders : int, list, array
+        The order of integration used in the quadrature routine
+    sigma : list, array
+        If one dimensional, the variance of the normal distribution being
+        approximated. If multidimensional, the variance-covariance matrix of
+        the multivariate normal process being approximated.
 
+    Returns
+    -------
+    x : array
+        Quadrature nodes
+    w : array
+        Quadrature weights
+    '''
     if isinstance(orders, int):
         orders = [orders]
 
@@ -75,7 +93,7 @@ def gauss_hermite_nodes(orders, sigma, mu=None):
     weights = [ h[1]/numpy.sqrt( numpy.pi) for h in herms]
 
     if len(orders) == 1:
-        x = numpy.array(points)*sigma
+        x = numpy.array(points)*numpy.sqrt(sigma)
         w = weights[0]
         return [x.T,w]
 
@@ -102,7 +120,7 @@ def gauss_hermite_nodes(orders, sigma, mu=None):
 
 #from numpy.polynomial.hermite import hermgauss
 
-           
+
 if __name__ == '__main__':
 
     orders = [8,8]

--- a/dolo/numeric/discretization/quadrature.py
+++ b/dolo/numeric/discretization/quadrature.py
@@ -93,6 +93,7 @@ def gauss_hermite_nodes(orders, sigma, mu=None):
     weights = [ h[1]/numpy.sqrt( numpy.pi) for h in herms]
 
     if len(orders) == 1:
+        # Note: if sigma is 2D, x will always be 2D, even if sigma is only 1x1.
         x = numpy.array(points)*numpy.sqrt(float(sigma))
         if sigma.ndim==2:
             x = x[:,None]

--- a/dolo/numeric/discretization/quadrature.py
+++ b/dolo/numeric/discretization/quadrature.py
@@ -59,12 +59,12 @@ def hermgauss(n):
 def gauss_hermite_nodes(orders, sigma, mu=None):
     '''
     Computes the weights and nodes for Gauss Hermite quadrature.
-    
+
     Parameters
     ----------
     orders : int, list, array
         The order of integration used in the quadrature routine
-    sigma : list, array
+    sigma : array-like
         If one dimensional, the variance of the normal distribution being
         approximated. If multidimensional, the variance-covariance matrix of
         the multivariate normal process being approximated.
@@ -93,9 +93,11 @@ def gauss_hermite_nodes(orders, sigma, mu=None):
     weights = [ h[1]/numpy.sqrt( numpy.pi) for h in herms]
 
     if len(orders) == 1:
-        x = numpy.array(points)*numpy.sqrt(sigma)
+        x = numpy.array(points)*numpy.sqrt(float(sigma))
+        if sigma.ndim==2:
+            x = x[:,None]
         w = weights[0]
-        return [x.T,w]
+        return [x,w]
 
     else:
         x = cartesian( points).T


### PR DESCRIPTION
Previously, in the one dimensional case the quadrature routine was constructing nodes using the variance of the normal distribution rather than the standard deviation. This is now corrected, and some documentation added to make it clear that the input to the function is the variance (or covariance matrix).