### PR TITLE
WIP: first implementation of custom dr.

### DIFF
--- a/dolo/compiler/factories.py
+++ b/dolo/compiler/factories.py
@@ -26,9 +26,9 @@ def reorder_preamble(pr):
     from dolang.triangular_solver import solve_triangular_system
     unknowns = [*pr.keys()]
     incidence = [[str(e) for e in sympy.sympify((exp)).atoms()]
-                 for exp in pr.values()]
+    for exp in pr.values()]
     sol = solve_triangular_system(dict(zip(unknowns, incidence)))
-    return dict([(k, pr[k]) for k in sol.keys()])
+    return dict([(k, pr[k]) for k in sol])
 
 
 def shift_spec(specs, tshift):

--- a/dolo/tests/test_customdr.py
+++ b/dolo/tests/test_customdr.py
@@ -1,0 +1,22 @@
+def test_custom_dr():
+
+    from dolo import yaml_import
+    import numpy as np
+    from dolo.numeric.decision_rule import CustomDR
+
+    model = yaml_import('examples/models/rbc.yaml')
+
+    values = {
+        'n': '0.33 + z*0.01',
+        'i': 'delta*k-0.07*(k-9.35497829)'
+    }
+
+    edr = CustomDR(values, model)
+
+    m0, s0 = model.calibration['exogenous','controls']
+
+    edr(m0, s0)
+
+    sim = simulate(model, edr, s0=np.array([0.0, 8.0]))
+
+    time_iteration(model, initial_guess=edr)

--- a/dolo/tests/test_customdr.py
+++ b/dolo/tests/test_customdr.py
@@ -1,6 +1,6 @@
 def test_custom_dr():
 
-    from dolo import yaml_import
+    from dolo import yaml_import, simulate, time_iteration
     import numpy as np
     from dolo.numeric.decision_rule import CustomDR
 


### PR DESCRIPTION
@pkofod , @llorracc-git

I made a quick first implementation of a custom decision rule, which can be constructed from explicit equations.

```
model = yaml_import('examples/models/rbc.yaml')
values = {
        'n': '0.33 + z*0.01',
        'i': 'delta*k-0.07*(k-9.35497829)'
}
edr = CustomDR(values, model)
time_iteration(model, initial_guess=edr)
```

There are some constraints for now:
1. the expressions depend on the values of the variables not their index if they are discretized
2. the values that one defines cannot depend on each other
3. it accepts the same functions as the model equations which are all differentiable functions. So no max or indicator function.

My plan is to do nothing about 1, but 2 and 3 should be fixed soon.
