### PR TITLE
Update installation.rst

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -58,7 +58,7 @@ After dolo is installed, try to solve a model by typing the following commands i
 .. code:: python
 
     from dolo import *                           # load the library
-    model = yaml_import("https://github.com/EconForge/dolo/blob/master/examples/models/compat/rbc.yaml")
+    model = yaml_import("https://raw.githubusercontent.com/EconForge/dolo/master/examples/models/rbc.yaml")
                                                  # import the model
     display(model)                               # display the model
     dr = time_iteration(model, verbose=True)     # solve


### PR DESCRIPTION
Since the URL in the official document is expired, Dolo wouldn't be implemented if a beginner just follows the instruction in the manual. Unfortunately, it is not easy for a beginner to discern where the running error comes from.  Since they are likely to misunderstand that some installation is failed, although it is done well, it is quite necessary to update the url. 

I replace the expired URL with the new valid one, which is the RBC example provided by Pablo Winant. 

Hope this may  help this community. 