### PR TITLE
model.exogenous.Sigma obsolete for new MvNormal, change it to Greek

### DIFF
--- a/dolo/algos/perturbations_higher_order.py
+++ b/dolo/algos/perturbations_higher_order.py
@@ -20,7 +20,8 @@ def perturb(model, order=1, return_dr=True, steady_state=None, verbose=True):
         calibration = steady_state
 
     [f, g] = get_model_derivatives(model, order=order, calibration=calibration)
-    sigma = model.exogenous.Sigma
+    #sigma = model.exogenous.Sigma
+    sigma = model.exogenous.Σ
 
     problem = PerturbationProblem(f,g,sigma)
     print(len(problem.f))

--- a/dolo/algos/perturbations_higher_order.py
+++ b/dolo/algos/perturbations_higher_order.py
@@ -20,7 +20,6 @@ def perturb(model, order=1, return_dr=True, steady_state=None, verbose=True):
         calibration = steady_state
 
     [f, g] = get_model_derivatives(model, order=order, calibration=calibration)
-    #sigma = model.exogenous.Sigma
     sigma = model.exogenous.Σ
 
     problem = PerturbationProblem(f,g,sigma)


### PR DESCRIPTION
Using the perturb function (for BGM) I received the following error message:
- 'Normal' object has no attribute 'Sigma'

I changed model.exogenous.Sigma to model.exogenous.Σ

@albop Does it seem coherent for the rest of the code?